### PR TITLE
Update Repository layout section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,7 @@ This repository contains the reference specification for the Quil language in
 addition to some useful extras outlined below.
 
 Repository layout:
-- `/examples`: examples of Quil
 - `/grammars`: example grammars used by parser generators
-- `/paper`: the source and rendered files for the Quil reference paper, by
-Smith et al
 - `/rfcs`: proposals for adding features or changing Quil
 - `/spec`: the Quil language specification
 


### PR DESCRIPTION
Update Repository layout section to match the actual layout. The `/examples` and `/paper` sub-directories don't exist.