### PR TITLE
Flesh out RESET discussion in Quil spec

### DIFF
--- a/spec/Quil.md
+++ b/spec/Quil.md
@@ -55,12 +55,14 @@ and in general any finite collection of qubits may interact. Physical devices,
 however, may impose constraints on the number of qubits and their allowed
 interactions.
 
+(Currently, Quil has no provisions for allocating an unbounded number of qubits at runtime. The number of qubits used by a program can be statically determined.)
+
 **For the purposes of this document**, a full description of the state of a set
 of n qubits will usually be expressed via an associated 2ⁿ-dimensional
 _wavefunction_. Quil expresses quantum computations with respect to a fixed
 computational basis. Thus a wavefunction may be expressed as a linear
 combination of _basis elements_, which are written as `|b⟩` for a bitstring b of
-length n. For example, the _Bell state_, which we write as `(|00⟩ + |11⟩)/sqrt(2)`, 
+length `n`. For example, the _Bell state_, which we write as `(|00⟩ + |11⟩)/sqrt(2)`, 
 is a combination of two basis elements. Given some collection of qubits, the 
 _zero state_ is that state in which each qubit is deterministically zero. The
 corresponding wavefunction is `|00...0⟩`.
@@ -75,7 +77,7 @@ consider simple probabilistic statements (e.g. "the system is in state A or B,
 each with probability 1/2"). This is particularly relevant when considering the
 meaning of Quil programs involving measurement or classical control flow.
 
-A fuller discussion of the semantics of Quil may be found in the original Quil whitepaper
+A fuller discussion of the semantics of this aspect of Quil may be found in the original Quil whitepaper
 ```
 R. Smith, M. J. Curtis and W. J. Zeng, "A Practical Quantum Instruction Set Architecture," (2016), 
   arXiv:1608.03355 [quant-ph], https://arxiv.org/abs/1608.03355
@@ -602,7 +604,7 @@ JUMP-WHEN @end-reset ro
 X q
 LABEL @end-reset
 ```
-which brings qubit q to the zero state. 
+which brings qubit `q` to the zero state.  This is sometimes called **active reset**.
 
 Note: The resulting quantum system is generally described by a mixed state. For
 example, supposing that we have prepared the Bell state `(|00⟩ + |11⟩)/sqrt(2)`,

--- a/spec/Quil.md
+++ b/spec/Quil.md
@@ -77,10 +77,15 @@ consider simple probabilistic statements (e.g. "the system is in state A or B,
 each with probability 1/2"). This is particularly relevant when considering the
 meaning of Quil programs involving measurement or classical control flow.
 
-A fuller discussion of the semantics of this aspect of Quil may be found in the original Quil whitepaper
+A fuller discussion of related aspects of Quil semantics may be found in the original whitepaper
 ```
 R. Smith, M. J. Curtis and W. J. Zeng, "A Practical Quantum Instruction Set Architecture," (2016), 
   arXiv:1608.03355 [quant-ph], https://arxiv.org/abs/1608.03355
+```
+For a detailed treatment of index notation and the interpretation of gate applications, see
+```
+R. Smith, "Someone Shouts ``|01000⟩!'' Who is excited?," (2017), 
+  arXiv:1711.02086 [quant-ph], https://arxiv.org/abs/1711.02086
 ```
 
 ## 2. Language

--- a/spec/Quil.md
+++ b/spec/Quil.md
@@ -42,6 +42,47 @@ Line 1
 The remainder of this document serves as a reference for all Quil language
 constructs and their associated semantics.
 
+### Semantic Conventions
+
+In describing the meaning or interpretation of certain instructions, we will
+have occasion to speak of notions such as "quantum state", "collapse of the
+wavefunction", and so forth. Here we briefly collect some relevant remarks.
+
+A Quil program manipulates a collection of classical and quantum resources. The
+quantum resources consist of a set of _qubits_, which are usually referred to by
+numerical indices. There is no bound on the number of qubits in a Quil program,
+and in general any finite collection of qubits may interact. Physical devices,
+however, may impose constraints on the number of qubits and their allowed
+interactions.
+
+**For the purposes of this document**, a full description of the state of a set
+of n qubits will usually be expressed via an associated 2ⁿ-dimensional
+_wavefunction_. Quil expresses quantum computations with respect to a fixed
+computational basis. Thus a wavefunction may be expressed as a linear
+combination of _basis elements_, which are written as `|b⟩` for a bitstring b of
+length n. For example, the _Bell state_, which we write as `(1/sqrt(2))(|00⟩ + |11⟩)`, 
+is a combination of two basis elements. Given some collection of qubits, the 
+_zero state_ is that state in which each qubit is deterministically zero. The
+corresponding wavefunction is `|00...0⟩`.
+
+**Note:** we also adopt the convention that the "i-th" entry of a bitstring is
+to be considered from right-to-left, starting from zero. Thus in `|001⟩`, the
+zeroth bit is 1, while bits one and two are 0.
+
+TODO: Include whatever discussion is needed about gates and measurement.
+
+It will sometimes be convenient to speak of _mixed states_. Here we
+intentionally keep the discussion light: for the most part, it will suffice to
+consider simple probabilistic statements (e.g. "the system is in state A or B,
+each with probability 1/2"). This is particularly relevant when considering the
+meaning of Quil programs involving measurement or classical control flow.
+
+A fuller discussion of the semantics of Quil may be found in the original Quil whitepaper
+```
+R. Smith, M. J. Curtis and W. J. Zeng, "A Practical Quantum Instruction Set Architecture," (2016), 
+  arXiv:1608.03355 [quant-ph], https://arxiv.org/abs/1608.03355
+```
+
 ## 2. Language
 
 ### Whitespace and Instructions
@@ -523,17 +564,38 @@ DEFGATE PSWAP(%theta):
 
 ### Qubit and State Reset
 
-TODO
-
-State reset
-```
-RESET
-```
+The following operations allow for some or all of the quantum state to be
+brought to a known reference value.
 
 Qubit reset
 ```
 RESET q
 ```
+is semantically equivalent to
+```
+DECLARE ro BIT
+MEASURE q ro
+JUMP-WHEN @end-reset ro
+X q
+LABEL @end-reset
+```
+which brings qubit q to the zero state. 
+
+Note: The resulting quantum system is generally described by a mixed state. For
+example, supposing that we have prepared the Bell state `(|00⟩ + |11⟩)/sqrt(2)`,
+the effect of resetting qubit 0 is to put the system into either state `|00⟩` or
+`|10⟩`, each with probability 1/2.
+
+
+State reset
+```
+RESET
+```
+is semantically equivalent to sequentially resetting all qubits
+```
+RESET 0 ; RESET 1 ; ...
+```
+which brings the full quantum state to the zero state.
 
 ## 4. Measurement and Classical Memory
 

--- a/spec/Quil.md
+++ b/spec/Quil.md
@@ -609,7 +609,7 @@ JUMP-WHEN @end-reset ro
 X q
 LABEL @end-reset
 ```
-which brings qubit `q` to the zero state.  This is sometimes called **active reset**.
+which brings qubit `q` to the zero state.  This is sometimes called _active reset_.
 
 Note: The resulting quantum system is generally described by a mixed state. For
 example, supposing that we have prepared the Bell state `(|00⟩ + |11⟩)/sqrt(2)`,

--- a/spec/Quil.md
+++ b/spec/Quil.md
@@ -562,41 +562,6 @@ DEFGATE PSWAP(%theta):
     0, 0,           0,           1
 ```
 
-### Qubit and State Reset
-
-The following operations allow for some or all of the quantum state to be
-brought to a known reference value.
-
-Qubit reset
-```
-RESET q
-```
-is semantically equivalent to
-```
-DECLARE ro BIT
-MEASURE q ro
-JUMP-WHEN @end-reset ro
-X q
-LABEL @end-reset
-```
-which brings qubit q to the zero state. 
-
-Note: The resulting quantum system is generally described by a mixed state. For
-example, supposing that we have prepared the Bell state `(|00⟩ + |11⟩)/sqrt(2)`,
-the effect of resetting qubit 0 is to put the system into either state `|00⟩` or
-`|10⟩`, each with probability 1/2.
-
-
-State reset
-```
-RESET
-```
-is semantically equivalent to sequentially resetting all qubits
-```
-RESET 0 ; RESET 1 ; ...
-```
-which brings the full quantum state to the zero state.
-
 ## 4. Measurement and Classical Memory
 
 ### Classical Memory Declarations
@@ -621,7 +586,40 @@ MEASURE 0 ro[0]
 MEASURE 1 ro[1]
 ```
 
-## 5. Classical Operations and Control Flow
+## 5. Other Quantum Operations
+
+The following operations allow for some or all of the quantum state to be
+brought to a known reference value.
+
+### Qubit reset
+
+```
+RESET q
+```
+is semantically equivalent to
+```
+DECLARE ro BIT
+MEASURE q ro
+JUMP-WHEN @end-reset ro
+X q
+LABEL @end-reset
+```
+which brings qubit q to the zero state. 
+
+Note: The resulting quantum system is generally described by a mixed state. For
+example, supposing that we have prepared the Bell state `(|00⟩ + |11⟩)/sqrt(2)`,
+the effect of resetting qubit 0 is to put the system into either state `|00⟩` or
+`|10⟩`, each with probability 1/2.
+
+### State reset
+
+```
+RESET
+```
+is semantically equivalent to sequentially resetting all qubits `RESET 0 ; RESET 1 ; ...`
+and brings the full quantum state to the zero state.
+
+## 6. Classical Operations and Control Flow
 
 TODO
 
@@ -653,7 +651,7 @@ LABEL @start
 LABEL @MY-LABEL
 ```
 
-## 6. Language Features
+## 7. Language Features
 
 ### File Inclusion
 
@@ -671,7 +669,7 @@ TODO
 PRAGMA <word> <word>* "string"?
 ```
 
-## 7. Circuits
+## 8. Circuits
 
 ### Circuit Definitions
 

--- a/spec/Quil.md
+++ b/spec/Quil.md
@@ -60,7 +60,7 @@ of n qubits will usually be expressed via an associated 2ⁿ-dimensional
 _wavefunction_. Quil expresses quantum computations with respect to a fixed
 computational basis. Thus a wavefunction may be expressed as a linear
 combination of _basis elements_, which are written as `|b⟩` for a bitstring b of
-length n. For example, the _Bell state_, which we write as `(1/sqrt(2))(|00⟩ + |11⟩)`, 
+length n. For example, the _Bell state_, which we write as `(|00⟩ + |11⟩)/sqrt(2)`, 
 is a combination of two basis elements. Given some collection of qubits, the 
 _zero state_ is that state in which each qubit is deterministically zero. The
 corresponding wavefunction is `|00...0⟩`.

--- a/spec/Quil.md
+++ b/spec/Quil.md
@@ -616,8 +616,8 @@ the effect of resetting qubit 0 is to put the system into either state `|00⟩` 
 ```
 RESET
 ```
-is semantically equivalent to sequentially resetting all qubits `RESET 0 ; RESET 1 ; ...`
-and brings the full quantum state to the zero state.
+brings the full quantum state to the zero state. This is semantically equivalent to 
+sequentially resetting all qubits (e.g. `RESET 0 ; RESET 1 ; ...`).
 
 ## 6. Classical Operations and Control Flow
 

--- a/spec/Quil.md
+++ b/spec/Quil.md
@@ -69,8 +69,6 @@ corresponding wavefunction is `|00...0⟩`.
 to be considered from right-to-left, starting from zero. Thus in `|001⟩`, the
 zeroth bit is 1, while bits one and two are 0.
 
-TODO: Include whatever discussion is needed about gates and measurement.
-
 It will sometimes be convenient to speak of _mixed states_. Here we
 intentionally keep the discussion light: for the most part, it will suffice to
 consider simple probabilistic statements (e.g. "the system is in state A or B,
@@ -616,7 +614,7 @@ the effect of resetting qubit 0 is to put the system into either state `|00⟩` 
 ```
 RESET
 ```
-brings the full quantum state to the zero state. This is semantically equivalent to 
+brings the full quantum system to the zero state. This is semantically equivalent to 
 sequentially resetting all qubits (e.g. `RESET 0 ; RESET 1 ; ...`).
 
 ## 6. Classical Operations and Control Flow


### PR DESCRIPTION
As part of the march towards having a fully-articulated language spec, I've added some discussion on `RESET`, as well as a bit of a preface on "semantics" more broadly. I've hoped to strike a balance between the legal obligation for introducing terminology while at the same time not bogging the document down too much. 

One point, which I hope is clear, is that Quil does not (in my opinion) really require any one particular mode of "interpretation" (e.g. in principle the semantic discussion can be formulated in terms of wavefunctions and collapse, or density matrices, or perhaps even the evolution of other more esoteric mathematical objects: discrete Wigner functions, something involving finite C* algebras, whatever). I've tried to, in a small way, distinguish between what is necessary for speaking about quil proper vs what is convenient for writing a spec (one example of this is the choice of right-to-left vs left-to-right convention for indexing bitstrings). 

Also the TODO I introduced is an honest one. I'll be filling out several of the other sections in a piecemeal fashion over the next week or two, and so I wish to defer measurement etc stuff until that time.