### PR TITLE
Misc Quilt Spec Updates

### DIFF
--- a/rfcs/analog/proposal.md
+++ b/rfcs/analog/proposal.md
@@ -123,17 +123,19 @@ a qubit which happens at the same time as a readout pulse.
 
 The finest granularity of timing information considered here is at the frame
 level. One model of semantics, which we outline here, is to consider that each
-frame (on a particular set of qubits) has a "local clock", which may be
-represented as a single real number. This clock may be "advanced" by a
-non-negative value. Thus, the frame clock are monotonically increasing during
+frame (on a particular set of qubits) has a _local clock_, which may be
+represented as a single real number. This clock may be _advanced_ by a
+non-negative value. Thus, frame clocks are monotonically increasing during
 program execution.
 
 Under this model:
-- pulse operations and frame mutations have a well defined local time at which
-  they _occur_.
-- pulse operations on a given qubit do not overlap in time, unless the
+- Instructions have the additional effect of advancing frame clocks.
+- Pulse operations and frame mutations have a well defined local time at which
+  they _occur_. Instructions involving multiple frames promise a form of
+  consistency: the local clocks are advanced to a consistent state so that the
+  time of occurrence is common across frames.
+- Pulse operations on a given qubit do not overlap in time, unless the
   `NONBLOCKING` modifier is used.
-- instructions have the additional effect of advancing frame clocks.
 
 #### Pulse Operations
 

--- a/rfcs/analog/proposal.md
+++ b/rfcs/analog/proposal.md
@@ -28,7 +28,7 @@ Quil instruction types:
 - DELAY
 - FENCE
 - PULSE
-- CAPTURE
+- CAPTURE, RAW-CAPTURE
 - SET-FREQUENCY, SET-SCALE
 - SET-PHASE, SHIFT-PHASE, SWAP-PHASES
 
@@ -48,10 +48,11 @@ the _sample rate_, which is in units of samples per second.
 **NOTE**: Quilt frames also have an associated sample rate, which may be
 specified in the corresponding `DEFFRAME` block, and are ultimately
 determined/enforced at link time by the underlying control hardware which the
-frame is associated to. It is an error to apply a custom waveform (via `PULSE`
-or `CAPTURE`) to a frame for which it has an incompatible sample rate.
+frame is associated to. If a custom waveform is applied (via `PULSE` or
+`CAPTURE`) to a frame for which it has an incompatible sample rate, the behavior
+is undefined.
 
-There are also some built-in waveform generator which take as a parameter the
+There are also some built-in waveform generators which take as a parameter the
 duration of the waveform in seconds, alleviating the need to know the sample
 rate to calculate duration. These are valid for use regardless of the frame's
 underlying sample rate.
@@ -134,7 +135,8 @@ Under this model:
 - Pulse operations and frame mutations have a well defined local time at which
   they _occur_. Instructions involving multiple frames promise a form of
   consistency: the local clocks are advanced to a consistent state so that the
-  time of occurrence is common across frames.
+  time of occurrence is common across frames. Note that this does not apply to
+  `DELAY` instructions.
 - Pulse operations on a given qubit do not overlap in time, unless the
   `NONBLOCKING` modifier is used.
 
@@ -147,9 +149,9 @@ The pulse occurs at the pulse frame's local time. The pulse has the effect of
 advancing the pulse frame's local clock by the waveform duration.
 
 Each frame is defined relative to a set of qubits. Two frames with a common
-qubit are said to _intersect_. All intersecting frames shall have their local
-clocks advanced to the maximum of their current value and the updated clock
-value of the pulse frame.
+qubit are said to _intersect_. All frames intersecting the pulse frame shall
+have their local clocks advanced to the maximum of their current value and the
+updated clock value of the pulse frame.
 
 ##### NONBLOCKING
 

--- a/rfcs/analog/proposal.md
+++ b/rfcs/analog/proposal.md
@@ -45,10 +45,11 @@ envelope, along with a sample rate. Each complex number represents one sample of
 the waveform. The exact time to play a waveform can be determined by dividing by
 the _sample rate_, which is in units of samples per second.
 
-**NOTE**: Quilt frames also have an associated sample rate, which are determined
-at link time by the underlying control hardware which the frame is associated
-to. It is an error to apply a custom waveform (via `PULSE` or `CAPTURE`) to a
-frame for which it has an incompatible sample rate.
+**NOTE**: Quilt frames also have an associated sample rate, which may be
+specified in the corresponding `DEFFRAME` block, and are ultimately
+determined/enforced at link time by the underlying control hardware which the
+frame is associated to. It is an error to apply a custom waveform (via `PULSE`
+or `CAPTURE`) to a frame for which it has an incompatible sample rate.
 
 There are also some built-in waveform generator which take as a parameter the
 duration of the waveform in seconds, alleviating the need to know the sample
@@ -162,15 +163,18 @@ the clocks of intersecting frames_.
 
 A `DELAY` instruction advances the local clocks of all specified frames by the
 specified delay amount. If the `DELAY` instruction specifies a list of qubits
-with no frame names, _all frames on these qubits have their clocks
+with no frame names, _all frames on exactly these qubits have their clocks
 advanced_.
+
+For example, `DELAY 0 1.0` delays all one qubit frames on qubit 0. It would not
+affect `0 1 "cz"`.
 
 #### Fence
 
 The `FENCE` instruction guarantees that all frames intersecting the specified
-qubits have their clocks advanced to the same value. The specific value is
-unspecified; the only requirement is that it be not less than the local clock
-values for any involved frames.
+qubits have their clocks advanced to the same value. This value is unspecified;
+the only requirement is that it be not less than the local clock values for any
+involved frames.
 
 #### Frame Mutations
 

--- a/rfcs/analog/proposal.md
+++ b/rfcs/analog/proposal.md
@@ -161,8 +161,9 @@ the clocks of intersecting frames_.
 #### Delay
 
 A `DELAY` instruction advances the local clocks of all specified frames by the
-specified delay amount. If the `DELAY` instruction specifies a qubit but no
-frames, _all frames intersecting this qubit have their clocks advanced_.
+specified delay amount. If the `DELAY` instruction specifies a list of qubits
+with no frame names, _all frames on these qubits have their clocks
+advanced_.
 
 #### Fence
 
@@ -357,7 +358,7 @@ DEFCAL RESET %qubit:
     RX(pi) %qubit
     JUMP @end
     LABEL delay
-    DELAY(60e-9) %qubit
+    DELAY %qubit 60e-9
     LABEL end
 ```
 

--- a/rfcs/analog/proposal.md
+++ b/rfcs/analog/proposal.md
@@ -28,23 +28,32 @@ Quil instruction types:
 - DELAY
 - FENCE
 - PULSE
+- CAPTURE
 - SET-FREQUENCY, SET-SCALE
 - SET-PHASE, SHIFT-PHASE, SWAP-PHASES
 
 ### Frames and Waveforms
 
-Each qubit can have multiple frames, defined by string names such as "xy", "cz",
+Each qubit can have multiple frames, denoted by string names such as "xy", "cz",
 or "ro". A frame is an abstraction that captures the instantaneous frequency and
 phase that will be mixed into the control signal. The frame frequencies are with
 respect to the absolute "lab frame".
 
-Waveforms are defined using DEFWAVEFORM as a list of complex numbers which
-represent the desired waveform envelope. Each complex number represents one
-sample of the waveform. The exact time to play a waveform can be determined by
-dividing by the sample rate for a qubit frame, which is in units of samples per
-second. There are also some built-in waveform shapes which take as a parameter
-the duration of the waveform in seconds, alleviating the need to know the sample
-rate to calculate duration.
+Quilt has two notions of _waveforms_. Custom waveforms are defined using
+DEFWAVEFORM as a list of complex numbers which represent the desired waveform
+envelope, along with a sample rate. Each complex number represents one sample of
+the waveform. The exact time to play a waveform can be determined by dividing by
+the _sample rate_, which is in units of samples per second.
+
+**NOTE**: Quilt frames also have an associated sample rate, which are determined
+at link time by the underlying control hardware which the frame is associated
+to. It is an error to apply a custom waveform (via `PULSE` or `CAPTURE`) to a
+frame for which it has an incompatible sample rate.
+
+There are also some built-in waveform generator which take as a parameter the
+duration of the waveform in seconds, alleviating the need to know the sample
+rate to calculate duration. These are valid for use regardless of the frame's
+underlying sample rate.
 
 In order to materialize the precise waveforms to be played the waveform
 envelopes must be modulated by the frame's frequency, in addition to applying
@@ -65,6 +74,7 @@ tracked through the program:
 | Frequency | (not set)     | Real numbers          | No                    |
 | Phase     | 0.0           | Real numbers          | Yes                   |
 | Scale     | 1.0           | Real numbers          | No                    |
+
 
 ### Pulses
 

--- a/rfcs/analog/scheduling.md
+++ b/rfcs/analog/scheduling.md
@@ -120,8 +120,8 @@ A _path_ is a sequence e(1), ..., e(n) of events, ordered by start time, such
 that, for 1 <= i < n,
 
 -   (obstructed successor) the frame of e(i+1) is obstructed by the instruction of e(i)
--   (earliest successor) amongst scheduled events satisfying (blocked), e(i+1)
-    is the earliest which start after e(i).
+-   (earliest successor) amongst scheduled events obstructed by and starting after e(i), the event e(i+1)
+    is the earliest.
 
 For example,
 ```

--- a/rfcs/analog/scheduling.md
+++ b/rfcs/analog/scheduling.md
@@ -1,0 +1,229 @@
+# Scheduling of Quilt Programs
+
+## Instructions, Events, and Frames
+
+### Events
+
+An _event_ is comprised of:
+-   start time
+-   end time
+-   a frame
+-   a parent instruction
+
+The duration of an event, (end time - start time), must be nonnegative.
+
+### Obstructed Frames
+
+Each instruction has a set of _obstructed_ frames. These determine which events
+can be scheduled concurrently.
+
+-   Generically, `PULSE`, `CAPTURE`, `RAW-CAPTURE` obstruct all frames sharing a qubit
+    with the target frame.
+-   If `NONBLOCKING`, the above instructions obstruct only their target frame.
+-   Simple frame mutations (i.e. `SET-*`) obstruct their target frame.
+-   `DELAY` obstructs the set of delayed frames
+-   FENCE obstructs all frames sharing a qubit with the listed qubits
+-   SWAP-PHASE obstructs the two listed frames
+
+### Schedules
+
+A schedule for a program is nothing more than a fully elaborated set of events,
+_with each instruction parent to a single event on each of its obstructed
+frames_.
+
+### Simple vs Compound Instructions
+
+Simple instructions have a well defined _duration_, which for some may be
+explicit and unambiguous (e.g. pulse ops), and for others may be hardware
+dependent (e.g. frame mutations).
+
+Compound instructions do not in general have a well defined global duration.
+
+#### "Simple" instructions
+
+-   `PULSE`, `CAPTURE`, `RAW-CAPTURE` have explicit durations indicated by the
+    waveform or raw capture duration.
+-   `DELAY` on a single frame has an explicit duration.
+-   `SET-*` have a hardware-dependent (perhaps nearly zero) duration
+
+#### "Compound" instructions
+
+-   `DELAY` on multiple frames is syntactic sugar for a `DELAY` on each of its
+    frames. We exclude this from the remaining discussion.
+-   `FENCE` may resolve to events on each obstructed frame with varying durations.
+-   `SWAP-PHASE` may resolve to events one each obstructed frame with varying durations.
+
+## Schedules and Consistency
+
+With respect to a schedule, the _timeline_ associated to a frame is the
+ordered (by start time) sequence of events on this frame. 
+
+### Consistency
+
+A schedule is said to be _consistent_ if it satisfies the following:
+1.  (monotonicity of time) events durations are non-negative
+2.  (simple duration) simple event durations agree with their instruction durations
+3.  (exclusion) for any frame timeline, no two events overlap
+4.  (order preservation) for any frame timeline, event A precedes B if and only
+    if the instruction associated to A precedes the instruction associated with
+    B relative to a frame-local program counter
+5.  (atomicity) for a simple instruction, all event start times are equal.
+    likewise, all end times are equal.
+6.  (synchronization) for a compound instruction, all event end times are equal.
+
+### Non-Uniqueness of Consistent Schedules
+
+Consistent schedules are generally not unique. There are a few sources of
+non-uniqueness.
+
+-   The initial events in each timeline can have their start times shifted by an
+    arbitrary constant. Thus we occasionally standardize things by setting the
+    start time of the earliest event to 0.
+-   The events themselves may be rescheduled within some block of time. For
+    example, in (abbreviationg waveforms to their durations)
+    ```
+    FENCE 0 1
+    PULSE 0 "xy" 1.0
+    PULSE 1 "xy" 2.0
+    FENCE 0 1
+    ```
+    there are many consistent schedules, which start the pulse operations at
+    varying times. Even more simply, one could suppose `PULSE 0 "xy" ; PULSE
+    0 "xy" ` is scheduled with dead time between the two pulses.
+-   `FENCE` and `SWAP-PHASE` instructions may have arbitrary event durations
+    (e.g. supposing a FENCE corresponds to events with durations d(1), ...,
+    d(k), one may obtain a consistent schedule by adding a constant to the end
+    time of each event, resulting in durations d(1) + c, ..., d(k) + c).
+
+## Tightness and Rigidity
+
+Consider the following program, with pulse waveforms omitted
+```
+PULSE 0 "xy"
+PULSE 0 "xy"
+PULSE 0 1 "ff"
+PULSE 1 "xy"
+PULSE 1 "xy"
+PULSE 0 1 "ff"
+PULSE 0 "xy"
+PULSE 0 "xy"
+```
+
+Once a start time has been set, there is a natural schedule associated with
+the above, imposed simply by the constraints of obstruction. For example, the
+initial two `0 "xy"` pulses obstruct the `0 1 "ff"` frame. The `0 1 "ff"`
+pulse may immediately follow these, and itself obstructs the `1 "xy"` frame,
+and so on.
+
+It is difficult to speak precisely about this without introducing some notation.
+A _path_ is a sequence e(1), ..., e(n) of events, ordered by start time, such
+that, for 1 <= i < n,
+
+-   (obstructed successor) the frame of e(i+1) is obstructed by the instruction of e(i)
+-   (earliest successor) amongst scheduled events satisfying (blocked), e(i+1)
+    is the earliest which start after e(i).
+
+For example,
+```
+PULSE 0 "xy"
+PULSE 1 "xy"
+PULSE 0 2 "ff"
+PULSE 2 "xy"
+```
+
+has a path of length 3 (coming from `PULSE 0 "xy" ; PULSE 0 2 "ff" ; PULSE 2
+"xy"`) and another of length 1 (from `PULSE 1 "xy"`).
+
+A consistent schedule is _tight_ if, for any path e(1),...,e(n), the start time
+of e(i+1) = the end time of e(i). In brief, at the end of each event, the next
+earliest obstructed event starts immediately.
+
+Two events s, t in a schedule are _connected_ if there is a path e(1),...,e(n)
+with s = e(1) and t = e(n). This relation partitions the schedule into
+_connected components_.
+
+A quilt block is _rigid_ if there exists a tight schedule subject to:
+1.  (fixed start) the earliest event in any component has start time 0.
+2.  (minimality) the end time of any FENCE and SWAP-PHASE instruction is minimal
+
+### Uniqueness
+
+**Proposition**: Every block admits at most one tight schedule subject to (fixed
+start) and (minimality).
+
+Sketch of Proof: Consider the result of consistent greedy scheduling subject to (fixed
+start) and (minimality). TODO
+
+We refer to this as the _rigid schedule_ associated with the block.
+
+### Failures of Rigidity
+
+By the uniqueness result, a block may fail to be rigid if no tight schedule
+satisfying (fixed start) and (minimality) exists.
+
+#### Missing Delay
+
+The following is not rigid (waveforms abbreviated to their durations),
+```
+PULSE 1 "xy" 2.0
+PULSE 0 "xy" 1.0
+PULSE 0 1 "ff" 1.0
+```
+because there does not exist any consistent, tight schedule satisfying (fixed start).
+
+However, with an additional `DELAY`, the result is rigid.
+```
+PULSE 1 "xy" 2.0
+DELAY 0 "xy" 1.0
+PULSE 0 "xy" 1.0
+PULSE 0 1 "ff" 1.0
+```
+or
+```
+PULSE 1 "xy" 2.0
+PULSE 0 "xy" 1.0
+DELAY 0 "xy" 1.0
+PULSE 0 1 "ff" 1.0
+```
+
+### The Duration of a Rigid Block
+
+A rigid block has a well-defined duration, indicated by the latest end time in
+its rigid schedule.
+
+### Establishing Rigidity
+
+Proposition: Any quilt program may be transformed to a corresponding rigid
+program through the insertion of DELAYS.
+
+## Promises to the Programmer
+
+In general, it is up to the compiler/translator to associate a consistent
+schedule to a quilt program. But how should rigid blocks be managed?
+
+### The challenge of preserving rigidity
+
+Considering the above example,
+```
+PULSE 1 "xy" 2.0
+PULSE 0 "xy" 1.0
+PULSE 0 1 "ff" 1.0
+```
+the first two instructions form a rigid block, and the last two instructions
+form a rigid block, but the set of three do not. In general, it should not be
+expected that rigidity of individual blocks be preserved. In this instance,
+the compiler/translator will be forced to decide when to schedule the pulse
+on `0 "xy"`.
+
+### `PRAGMA PRESERVE_RIGID_BLOCK`
+
+For systematic and predictable control over scheduling, users may surround a
+block with `PRAGMA PRESERVE_RIGID_BLOCK` and `PRAGMA END_PRESERVE_RIGID_BLOCK`.
+The signal to the compiler/translator is that, if the enclosed block is rigid,
+then the rigid schedule for this block will be used in the final schedule (up to
+a global time shift, since it may start at a nonzero time with respect to the
+global program.
+
+**By default, calibration bodies are treated as if they were surrounded by
+enclosing `PRAGMA PRESERVE_RIGID_BLOCK`.**
+

--- a/rfcs/analog/spec_changes.md
+++ b/rfcs/analog/spec_changes.md
@@ -298,23 +298,26 @@ the first calibration definition matches `T 0`, the second matches `DAGGER T 0`,
 and neither match `DAGGER DAGGER T 0`.
 
 
-### Timing Control
+### Timing and Synchronization
 
 ```
-Delay :: DELAY Qubit Expression ( FrameName )*
+Delay :: DELAY Qubit+ FrameName* Expression
 Fence :: FENCE Qubit+
 ```
 
 Delay allows for the insertion of a gap within a list of pulses or gates with
 a specified duration in seconds.
 
-If frame names are specified, then the delay instruction only affects frames
-with those names which intersect the qubit. If no frame names are specified, all
-frames which intersect the qubit are affected.
+If frame names are specified, then the delay instruction affects those frames on
+those qubits. If no frame names are specified, all frames on precisely those
+qubits are affected. **Note:** this excludes frames which _intersect_ the
+specified qubits but involve others. For example, `DELAY 0 1.0` delays one qubit
+frames on `0`, such as `0 "xy"`, but leaves other frames, such as `0 1 "cz"`,
+unaffected.
 
-Fence ensures that all operations on the specified qubits that proceed the
-fence statement happen after the end of the right-most operation of that set
-of qubits.
+Fence ensures that all operations involving the specified qubits that follow the
+fence statement happen after all operations involving the specified qubits that
+preceed the fence statement.
 
 Examples:
 ```

--- a/rfcs/analog/spec_changes.md
+++ b/rfcs/analog/spec_changes.md
@@ -16,12 +16,24 @@ list of qubits. Thus, `0 1 "cz"` is the "cz" frame on qubits 0 and 1. The order
 of the qubits matters. In particular, the above frame may differ from `1 0
 "cz"`.
 
-There are no built-in frames. The specific set of available frames is
-hardware-dependent.
+#### DEFFRAME
 
-Frames (and associated sample rates) need to be provided to the user prior to
-construction of a program. Rigetti has a set of canonical frames (some examples
-are below) but this is subject to change.
+There are no built-in frames. Frames must be defined using the `DEFFRAME`
+directive.
+
+```
+DefFrame :: DEFFRAME Frame (: FrameSpec+ )?
+FrameSpec :: Indent FrameAttr : Expression
+FrameAttr :: SAMPLE-RATE | INITIAL-FREQUENCY
+```
+
+All frames used in a program must have a corresponding top-level definition.
+
+
+Before execution, a Quilt program is linked with a specific system of control
+hardware, and frames are mapped to suitable hardware objects. Native or
+canonical frame definitions may be provided by a hardware vendor. Some examples
+of Rigetti's canonical frames are listed below, but this is subject to change.
 
 Examples (names only):
 ```

--- a/rfcs/analog/spec_changes.md
+++ b/rfcs/analog/spec_changes.md
@@ -301,12 +301,16 @@ and neither match `DAGGER DAGGER T 0`.
 ### Timing Control
 
 ```
-Delay :: DELAY Qubit Expression
+Delay :: DELAY Qubit Expression ( FrameName )*
 Fence :: FENCE Qubit+
 ```
 
 Delay allows for the insertion of a gap within a list of pulses or gates with
 a specified duration in seconds.
+
+If frame names are specified, then the delay instruction only affects frames
+with those names which intersect the qubit. If no frame names are specified, all
+frames which intersect the qubit are affected.
 
 Fence ensures that all operations on the specified qubits that proceed the
 fence statement happen after the end of the right-most operation of that set

--- a/rfcs/analog/spec_changes.md
+++ b/rfcs/analog/spec_changes.md
@@ -2,7 +2,7 @@ Add section 6 to spec:
 
 ## 6. Pulse Level Control
 
-**Frames**
+### Frames
 
 ```
 FrameName :: String
@@ -33,7 +33,7 @@ Examples (names only):
 "out" # eg. for the capture line
 ```
 
-**Waveforms**
+### Waveforms
 
 ```
 Waveform :: Name
@@ -81,7 +81,7 @@ The built-in waveform generators are:
     - `padright` is a rational number representing the amount of zero-amplitude
       padding to add to the right of the pulse
 
-**Defining new waveforms**
+#### Defining new waveforms
 
 ```
 SampleRate :: Float
@@ -107,7 +107,7 @@ The duration (in seconds) of a custom waveform may be computed by dividing the
 number of samples by the sample rate. In the above example, both waveforms have
 a duration of 0.5 seconds.
 
-**Pulses**
+### Pulses
 
 ```
 Pulse :: PULSE Frame Waveform
@@ -134,7 +134,9 @@ Each frame has a fixed, hardware-specific sample rate. The behavior of a `PULSE`
 instruction with a custom waveform whose sample rate does not match the
 corresponding frame's sample rate is undefined.
 
-**Frequency**
+### Frame Mutations
+
+#### Frequency
 
 ```
 SetFrequency :: SET-FREQUENCY Frame Float
@@ -150,7 +152,7 @@ SET-FREQUENCY 0 "xy" 5.4e9
 SET-FREQUENCY 0 "ro" 6.1e9
 ```
 
-**Phase**
+#### Phase
 
 ```
 SetPhase :: SET-PHASE Frame Float
@@ -179,7 +181,7 @@ SHIFT-PHASE 0 "xy" %theta*2/pi
 SWAP-PHASE 0 "xy" 1 "xy"
 ```
 
-**Scale**
+#### Scale
 
 ```
 SetScale :: SET-SCALE Frame Float
@@ -195,7 +197,7 @@ Example:
 SET-SCALE 0 "xy" 0.75
 ```
 
-**Capture**
+### Capture
 
 ```
 Capture :: CAPTURE Frame Waveform MemoryReference
@@ -227,6 +229,8 @@ The behavior of a `CAPTURE` instruction with a custom waveform whose sample rate
 does not match the corresponding frame's sample rate is undefined.
 
 **Defining Calibrations**
+
+### Defining Calibrations
 
 ```
 GateModifier :: CONTROLLED | DAGGER | FORKED
@@ -294,7 +298,7 @@ the first calibration definition matches `T 0`, the second matches `DAGGER T 0`,
 and neither match `DAGGER DAGGER T 0`.
 
 
-**Timing Control**
+### Timing Control
 
 ```
 Delay :: DELAY Qubit Expression


### PR DESCRIPTION
This incorporates much of discussion on 9/19/19 for which there was something of a consensus. The main change has to do with timing. I've elaborated on one aspect of the operational semantics -- namely, a notion of local clocks or "timekeepers" -- in `proposal.md`, but for now I'm leaving this out of `spec_changes.md`.

The principal language changes this incorporates are:

-  Timing is to be tracked at the frame level.
-  We are introducing a `NONBLOCKING` modifier for `PULSE`, `CAPTURE`, `RAW-CAPTURE` instructions which guarantees to not advance the local frame time
-  We’re extending `DELAY` to operate at the frame level. `DELAY 0 "foo" "bar" 1.0` delays frames "foo" and "bar" on qubit 0 by one second. `DELAY 0 1.0` delays all 1q frames on qubit 0,  `DELAY 0 1 1.0` delays 2q frames on 0 and 1, etc.

This also introduces a `DEFFRAME` directive. There was a bit less of a consensus on what this should look like. What's proposed here is what was suggested by @ecpeterson in conversation.

What is not yet included:
- Possibly introduce additional syntax for waveform expressions to allow affine transformations of these, which comfortably handles the common case (e.g. a*<waveform> + b) but allows for some generalization to multiple waveforms (e.g. a*(<waveform1>,...,<waveformk>) + b

This would be included with separate PRs.
