### PR TITLE
Quilt Enhancements

### DIFF
--- a/rfcs/analog/proposal.md
+++ b/rfcs/analog/proposal.md
@@ -175,7 +175,8 @@ qubit frames on qubit 0, but does not affect `0 1 "cz"`.
 The `FENCE` instruction provides a means of synchronization of all frames
 involving a set of qubits. In particular, it guarantees that all instructions
 involving any of the fenced qubits preceding the `FENCE` are completed before
-any instructions involving the fenced qubits which follow the `FENCE`
+any instructions involving the fenced qubits which follow the `FENCE`. If `FENCE`
+has no arguments, then it applies to all qubits on the device.
 
 #### Frame Mutations
 

--- a/rfcs/analog/proposal.md
+++ b/rfcs/analog/proposal.md
@@ -29,7 +29,8 @@ Quil instruction types:
 - FENCE
 - PULSE
 - CAPTURE, RAW-CAPTURE
-- SET-FREQUENCY, SET-SCALE
+- SET-SCALE
+- SET-FREQUENCY, SHIFT-FREQUENCY
 - SET-PHASE, SHIFT-PHASE, SWAP-PHASES
 
 ### Frames and Waveforms
@@ -178,7 +179,7 @@ any instructions involving the fenced qubits which follow the `FENCE`
 
 #### Frame Mutations
 
-Single frame mutations (`SET-FREQUENCY`, `SET-PHASE`, `SHIFT-PHASE`,
+Single frame mutations (`SET-FREQUENCY`, `SHIFT-FREQUENCY`, `SET-PHASE`, `SHIFT-PHASE`,
 `SET-SCALE`) have a hardware dependent duration (which may be effectively zero).
 These operations block pulses on the targeted frame.
 

--- a/rfcs/analog/spec_changes.md
+++ b/rfcs/analog/spec_changes.md
@@ -24,16 +24,17 @@ directive.
 ```
 DefFrame :: DEFFRAME Frame (: FrameSpec+ )?
 FrameSpec :: Indent FrameAttr : ( Expression | String )
-FrameAttr :: SAMPLE-RATE | INITIAL-FREQUENCY | DIRECTION
+FrameAttr :: SAMPLE-RATE | INITIAL-FREQUENCY | DIRECTION | HARDWARE-OBJECT
 ```
 
 All frames used in a program must have a corresponding top-level definition.
 
 
 Before execution, a Quilt program is linked with a specific system of control
-hardware, and frames are mapped to suitable hardware objects. Native or
-canonical frame definitions may be provided by a hardware vendor. Some examples
-of Rigetti's canonical frames are listed below, but this is subject to change.
+hardware, and frames are mapped to suitable hardware objects (cf. the
+`HARDWARE-OBJECT` frame attribute below). Native or canonical frame definitions may be
+provided by a hardware vendor. Some examples of Rigetti's canonical frames are
+listed below, but this is subject to change.
 
 Examples (names only):
 ```
@@ -53,6 +54,7 @@ Frame attributes represent quantities associated with a given frame which need n
 - `SAMPLE-RATE` is a floating point number indicating the rate (in Hz) of the digital-to-analog converter on the control hardware associated with this frame.
 - `INITIAL-FREQUENCY` is a floating point number indicating the initial frame frequency.
 - `DIRECTION` is one of `"tx"` or `"rx"`.
+- `HARDWARE-OBJECT` is a string indicating the (implementation-specific) hardware object that the frame is associated with.
 
 ### Waveforms
 

--- a/rfcs/analog/spec_changes.md
+++ b/rfcs/analog/spec_changes.md
@@ -18,7 +18,7 @@ of the qubits matters. In particular, the above frame may differ from `1 0
 
 #### DEFFRAME
 
-There are no built-in frames. Frames must be defined using the `DEFFRAME`
+Quilt itself has no built-in frames. Frames must be defined using the `DEFFRAME`
 directive.
 
 ```
@@ -161,16 +161,17 @@ corresponding frame's sample rate is undefined.
 
 ```
 SetFrequency :: SET-FREQUENCY Frame Float
+ShiftFrequency :: SHIFT-FREQUENCY Frame Float
 ```
 
-Each frame has a frequency which is tracked throughout the program. Initially
-the frequency starts out as not defined.
+Each frame has a frequency which is tracked throughout the program. Initial
+frame frequencies are specified in the frame definition's `INITIAL-FREQUENCY`
+attribute. Subsequent code may update this, either assigning an absolute value (`SET-FREQUENCY`) or a relative offset (`SHIFT-FREQUENCY`).
 
-Set instructions are local to the surrounding scope.
 
 ```
 SET-FREQUENCY 0 "xy" 5.4e9
-SET-FREQUENCY 0 "ro" 6.1e9
+SHIFT-FREQUENCY 0 "ro" 6.1e9
 ```
 
 #### Phase
@@ -188,9 +189,6 @@ with other frames.
 The phase must be a rational real number. There is also support for
 shifted the phase based on some expression, as long as that expression returns
 a real number.
-
-Set instructions are local to the surrounding scope, however shifting and
-swapping have global effect to the frame across the entire program.
 
 Example:
 ```
@@ -210,8 +208,6 @@ SetScale :: SET-SCALE Frame Float
 
 Each frame has a scale which is tracked throughout the program. Initially the
 scale starts out as 1.
-
-Set instructions are local to the surrounding scope.
 
 Example:
 ```

--- a/rfcs/analog/spec_changes.md
+++ b/rfcs/analog/spec_changes.md
@@ -319,7 +319,7 @@ and neither match `DAGGER DAGGER T 0`.
 
 ```
 Delay :: DELAY Qubit+ FrameName* Expression
-Fence :: FENCE Qubit+
+Fence :: FENCE Qubit*
 ```
 
 Delay allows for the insertion of a gap within a list of pulses or gates with
@@ -334,7 +334,8 @@ unaffected.
 
 Fence ensures that all operations involving the specified qubits that follow the
 fence statement happen after all operations involving the specified qubits that
-preceed the fence statement.
+preceed the fence statement. If no qubits are specified, the `FENCE` operation
+implicitly applies to all qubits on the device.
 
 Examples:
 ```


### PR DESCRIPTION
This includes three changes to Quilt:

1. An additional `SHIFT-FREQUENCY` instruction.
2. A global `FENCE`.
3. An extra frame attribute, `HARDWARE-OBJECT`.

Re: `HARDWARE-OBJECT`, this is a necessary bit of data that is not currently tracked in either the Quilt calibrations or on a `DeployedRack`. This would be a device-specific string indicating a piece of control hardware, and is needed for compilation. In some instances these will be 1-1 with frames, e.g. for Rigetti hardware, frame `0 "rf"` has hardware object `"q0_rf"`. In other instances, several frames will share a hardware object, e.g. `"q0_ff"` is used by several two-qubit frames touching qubit 0.